### PR TITLE
Don't log secretsAsEnv

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ getSecretValue(secretsManager, secretName)
         .join('\n')
 
       core.info(`New env file ${outputPath}`)
-      core.info(secretsAsEnv)
 
       fs.writeFileSync(outputPath, secretsAsEnv)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-secrets-manager-actions",
-  "version": "1.2.2-rc1",
+  "version": "1.3.1",
   "description": "GitHub Actions for AWS Secrets Manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Tiny PR, not really a fix but just a precaution. With the current setup we were/are logging `secretsAsEnv` before masking the secrets which exposed them in the GitHub Actions log. This PR just removes the log entirely. The other PR has worked as expected btw 🎉 